### PR TITLE
Fix: too many SQL variables on Delete

### DIFF
--- a/src/Microsoft.Azure.Mobile.Client/Authentication/MobileServicePKCEAuthentication.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Authentication/MobileServicePKCEAuthentication.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.WindowsAzure.MobileServices.Internal;
 
 #if PLATFORM_ANDROID || PLATFORM_IOS || PLATFORM_PCL
 using PCLCrypto;
@@ -22,7 +23,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         protected Uri LoginUri { get; private set; }
 
         protected Uri CallbackUri { get; private set; }
-        
+
         protected string CodeVerifier { get; private set; }
 
         protected MobileServicePKCEAuthentication(MobileServiceClient client, string provider, string uriScheme, IDictionary<string, string> parameters)
@@ -53,7 +54,7 @@ namespace Microsoft.WindowsAzure.MobileServices
             loginParameters.Add("session_mode", "token");
             var loginQueryString = MobileServiceUrlBuilder.GetQueryString(loginParameters, false);
             var loginPathAndQuery = MobileServiceUrlBuilder.CombinePathAndQuery(path, loginQueryString);
-            
+
             this.LoginUri = new Uri(this.Client.MobileAppUri, loginPathAndQuery);
             if (this.Client.AlternateLoginHost != null)
             {
@@ -65,7 +66,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// Login via OAuth 2.0 PKCE protocol.
         /// </summary>
         /// <returns></returns>
-        protected sealed override async Task<string> LoginAsyncOverride()
+        public sealed override async Task<string> LoginAsyncOverride()
         {
             // Show platform-specific login ui and care about handling authorization_code from callback via deep linking.
             var authorizationCode = await this.GetAuthorizationCodeAsync();

--- a/src/Microsoft.Azure.Mobile.Client/Microsoft.Azure.Mobile.Client.csproj
+++ b/src/Microsoft.Azure.Mobile.Client/Microsoft.Azure.Mobile.Client.csproj
@@ -36,6 +36,7 @@
     <None Include="**\*.cs;**\*.xml;**\*.axml" Exclude="obj\**\*.*;bin\**\*.*" />
     <Compile Remove="Platforms\**\*.*" />
     <EmbeddedResource Include="Properties\*.rd.xml" />
+    <None Remove="Platforms\netstandard20\PlatformInformation.cs" />
     <Compile Update="Resources.Designer.cs" DesignTime="true" AutoGen="true" DependentUpon="Resources.resx" />
     <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/android/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/android/Authentication/MobileServiceUIAuthentication.cs
@@ -17,9 +17,9 @@ namespace Microsoft.WindowsAzure.MobileServices.Internal
     internal class MobileServiceUIAuthentication : MobileServicePKCEAuthentication
     {
         public MobileServiceUIAuthentication(
-            MobileServiceClient client, 
-            string providerName, 
-            string uriScheme, 
+            MobileServiceClient client,
+            string providerName,
+            string uriScheme,
             IDictionary<string, string> parameters
         ) : base(client, providerName, uriScheme, parameters)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.WindowsAzure.MobileServices.Internal
         /// <exception cref="InvalidOperationException">
         ///     Thrown if the authentication fails.
         /// </exception>
-        public override async Task<string> GetAuthorizationCodeAsync()
+        protected override async Task<string> GetAuthorizationCodeAsync()
         {
             try
             {

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/ios/Authentication/MobileServiceUIAuthentication.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <exception cref="InvalidOperationException">
         ///     Thrown if the authentication fails.
         /// </exception>
-        public override async Task<string> GetAuthorizationCodeAsync()
+        protected override async Task<string> GetAuthorizationCodeAsync()
         {
             try
             {

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard20/ApplicationStorage.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard20/ApplicationStorage.cs
@@ -52,7 +52,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         bool IApplicationStorage.TryReadSetting(string name, out object value)
         {
             Arguments.IsNotNullOrWhiteSpace(name, nameof(name));
-            
+
             var filename = string.Concat(StoragePrefix, name);
             try
             {
@@ -61,9 +61,6 @@ namespace Microsoft.WindowsAzure.MobileServices
                 using var reader = new StreamReader(fileStream);
                 value = reader.ReadToEnd();
                 return value != null;
-            }
-                    }
-                }
             }
             catch
             {
@@ -96,9 +93,6 @@ namespace Microsoft.WindowsAzure.MobileServices
                 using IsolatedStorageFileStream fileStream = isoStore.OpenFile(filename, FileMode.OpenOrCreate, FileAccess.Write);
                 using var writer = new StreamWriter(fileStream);
                 writer.WriteLine(value.ToString());
-            }
-                    }
-                }
             }
             catch (Exception)
             {

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard20/PlatformInformation.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/netstandard20/PlatformInformation.cs
@@ -1,0 +1,42 @@
+﻿// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.WindowsAzure.MobileServices
+{
+    /// <summary>
+    /// Implements the <see cref="IPlatform"/> interface for the Windows
+    /// Phone platform.
+    /// </summary>
+    internal class PlatformInformation : IPlatformInformation
+    {
+        /// <summary>
+        /// A singleton instance of the <see cref="ApplicationStorage"/>.
+        /// </summary>
+        public static IPlatformInformation Instance { get; } = new PlatformInformation();
+
+        /// <summary>
+        /// The architecture of the platform.
+        /// </summary>
+        public string OperatingSystemArchitecture => RuntimeInformation.OSArchitecture.ToString();
+
+        /// <summary>
+        /// The name of the operating system of the platform.
+        /// </summary>
+        public string OperatingSystemName => RuntimeInformation.OSDescription;
+
+        /// <summary>
+        /// The version of the operating system of the platform.
+        /// </summary>
+        public string OperatingSystemVersion => Platform.UnknownValueString;
+
+        /// <summary>
+        /// Indicated whether the device is an emulator or not
+        /// </summary>
+        public bool IsEmulator => false;
+
+        public string Version => this.GetVersionFromAssemblyFileVersion();
+    }
+}

--- a/src/Microsoft.Azure.Mobile.Client/Platforms/uwp/Authentication/MobileServiceUIAuthentication.cs
+++ b/src/Microsoft.Azure.Mobile.Client/Platforms/uwp/Authentication/MobileServiceUIAuthentication.cs
@@ -39,7 +39,7 @@ namespace Microsoft.WindowsAzure.MobileServices
         /// <returns>
         /// Task that will complete with the authorization code when the user finishes authentication.
         /// </returns>
-        public override Task<string> GetAuthorizationCodeAsync()
+        protected override Task<string> GetAuthorizationCodeAsync()
         {
             var tcs = new TaskCompletionSource<string>();
 


### PR DESCRIPTION
When deleting more than 999 records, an exception is thrown:

> Microsoft.WindowsAzure.MobileServices.SQLiteStore.SQLiteException: Error executing SQLite command: 'too many SQL variables'.

Deleting too many records can happen in the offline-sync scenario when PullAction is invoked on a table with more than 999 soft-deleted records, for instance when initial sync is executed.